### PR TITLE
Fix potential crash in `didEndDisplayingCell`

### DIFF
--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		552163B528E1F314002B9218 /* UIView+TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 552163B428E1F314002B9218 /* UIView+TestHelpers.swift */; };
 		55226DFD28D87114004F8059 /* FeedLoaderCacheDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55226DFC28D87114004F8059 /* FeedLoaderCacheDecorator.swift */; };
 		55226DFF28D873C6004F8059 /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55226DFE28D873C6004F8059 /* FeedImageDataLoaderCacheDecoratorTests.swift */; };
 		55226E0128D87737004F8059 /* FeedImageDataLoaderSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55226E0028D87737004F8059 /* FeedImageDataLoaderSpy.swift */; };
@@ -77,6 +78,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		552163B428E1F314002B9218 /* UIView+TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+TestHelpers.swift"; sourceTree = "<group>"; };
 		55226DFC28D87114004F8059 /* FeedLoaderCacheDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecorator.swift; sourceTree = "<group>"; };
 		55226DFE28D873C6004F8059 /* FeedImageDataLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		55226E0028D87737004F8059 /* FeedImageDataLoaderSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderSpy.swift; sourceTree = "<group>"; };
@@ -211,22 +213,23 @@
 			isa = PBXGroup;
 			children = (
 				55AB1C5E28DDE59C006D3AB7 /* FeedImageCell+TestHelpers.swift */,
+				55226E0028D87737004F8059 /* FeedImageDataLoaderSpy.swift */,
+				5571BD3528D4D8F700389A6A /* FeedLoaderStub.swift */,
 				55AB1C5928DDE59C006D3AB7 /* FeedUIIntegrationTests+Assertions.swift */,
 				55AB1C5828DDE59C006D3AB7 /* FeedUIIntegrationTests+LoaderSpy.swift */,
 				55AB1C5F28DDE59C006D3AB7 /* FeedUIIntegrationTests+Localization.swift */,
 				55AB1C5C28DDE59C006D3AB7 /* FeedViewController+TestHelpers.swift */,
+				55AB1C7028DDFB36006D3AB7 /* HTTPClientStub.swift */,
+				55AB1C6E28DDFB10006D3AB7 /* InMemoryFeedStore.swift */,
+				5571BD3128D3986500389A6A /* SharedTestHelpers.swift */,
 				55AB1C5D28DDE59C006D3AB7 /* UIButton+TestHelpers.swift */,
 				55AB1C5A28DDE59C006D3AB7 /* UIControl+TestHelpers.swift */,
 				55AB1C5B28DDE59C006D3AB7 /* UIImage+TestHelpers.swift */,
 				55AB1C6028DDE59C006D3AB7 /* UIRefreshControl+TestHelpers.swift */,
-				5571BD2E28D397FD00389A6A /* XCTestCase+MemoryLeakTracking.swift */,
-				5571BD3928D4EB3F00389A6A /* XCTestCase+FeedLoader.swift */,
 				55226E0228D8779C004F8059 /* XCTestCase+FeedImageDataLoader.swift */,
-				5571BD3128D3986500389A6A /* SharedTestHelpers.swift */,
-				5571BD3528D4D8F700389A6A /* FeedLoaderStub.swift */,
-				55226E0028D87737004F8059 /* FeedImageDataLoaderSpy.swift */,
-				55AB1C6E28DDFB10006D3AB7 /* InMemoryFeedStore.swift */,
-				55AB1C7028DDFB36006D3AB7 /* HTTPClientStub.swift */,
+				5571BD3928D4EB3F00389A6A /* XCTestCase+FeedLoader.swift */,
+				5571BD2E28D397FD00389A6A /* XCTestCase+MemoryLeakTracking.swift */,
+				552163B428E1F314002B9218 /* UIView+TestHelpers.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -370,6 +373,7 @@
 				55AB1C6228DDE59C006D3AB7 /* FeedImageCell+TestHelpers.swift in Sources */,
 				5571BD2B28D38BB000389A6A /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */,
 				5571BD2728D3812E00389A6A /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,
+				552163B528E1F314002B9218 /* UIView+TestHelpers.swift in Sources */,
 				55AB1C6528DDE59C006D3AB7 /* UIButton+TestHelpers.swift in Sources */,
 				55AB1C6D28DDE9E9006D3AB7 /* FeedAcceptanceTests.swift in Sources */,
 				55AB1C6F28DDFB10006D3AB7 /* InMemoryFeedStore.swift in Sources */,

--- a/EssentialApp/EssentialAppTests/FeedUIIntegrationTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedUIIntegrationTests.swift
@@ -73,6 +73,21 @@ final class FeedUIIntegrationTests: XCTestCase {
         assertThat(sut, isRendering: [image0, image1, image2, image3])
     }
     
+    func test_loadCompletion_rendersSuccessfullyLoadedEmptyFeedAfterNonEmptyFeed() {
+        let (sut, loader) = makeSUT()
+        
+        let image0 = makeImage(description: "a description", location: "a location")
+        let image1 = makeImage(description: "a description", location: nil)
+        
+        sut.loadViewIfNeeded()
+        loader.completeFeedLoading(with: [image0, image1], at: 0)
+        assertThat(sut, isRendering: [image0, image1])
+    
+        sut.simulateUserInitiatedFeedReload()
+        loader.completeFeedLoading(with: [], at: 1)
+        assertThat(sut, isRendering: [])
+    }
+    
     func test_loadCompletion_doesNotAlterCurrentRenderingStateOnError() {
         let (sut, loader) = makeSUT()
         let image0 = makeImage()

--- a/EssentialApp/EssentialAppTests/Helpers/FeedUIIntegrationTests+Assertions.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedUIIntegrationTests+Assertions.swift
@@ -11,6 +11,9 @@ import EssentialFeediOS
 
 extension FeedUIIntegrationTests {
     func assertThat(_ sut: FeedViewController, isRendering images: [FeedImage], file: StaticString = #filePath, line: UInt = #line) {
+        sut.tableView.layoutIfNeeded()
+        RunLoop.main.run(until: Date())
+        
         guard sut.numberOfRenderedFeedImageViews == images.count else {
             XCTFail("Expected to render same amount views (\(sut.numberOfRenderedFeedImageViews)) as loaded (\(images.count))", file: file, line: line)
             return

--- a/EssentialApp/EssentialAppTests/Helpers/FeedUIIntegrationTests+Assertions.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedUIIntegrationTests+Assertions.swift
@@ -11,8 +11,7 @@ import EssentialFeediOS
 
 extension FeedUIIntegrationTests {
     func assertThat(_ sut: FeedViewController, isRendering images: [FeedImage], file: StaticString = #filePath, line: UInt = #line) {
-        sut.tableView.layoutIfNeeded()
-        RunLoop.main.run(until: Date())
+        sut.view.enforceLayoutCycle()
         
         guard sut.numberOfRenderedFeedImageViews == images.count else {
             XCTFail("Expected to render same amount views (\(sut.numberOfRenderedFeedImageViews)) as loaded (\(images.count))", file: file, line: line)
@@ -22,6 +21,8 @@ extension FeedUIIntegrationTests {
         images.enumerated().forEach { (index, image) in
             assertThat(sut, hasViewConfiguredAt: index, with: image)
         }
+        
+        executeRunLoopToCleanUpReferences()
     }
 
     func assertThat(_ sut: FeedViewController, hasViewConfiguredAt index: Int, with image: FeedImage, file: StaticString = #filePath, line: UInt = #line) {
@@ -34,5 +35,9 @@ extension FeedUIIntegrationTests {
         XCTAssertEqual(cell.isShowingLocation, image.location != nil, file: file, line: line)
         XCTAssertEqual(cell.locationText, image.location, file: file, line: line)
         XCTAssertEqual(cell.descriptionText, image.description, file: file, line: line)
+    }
+    
+    private func executeRunLoopToCleanUpReferences() {
+        RunLoop.current.run(until: Date())
     }
 }

--- a/EssentialApp/EssentialAppTests/Helpers/UIView+TestHelpers.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/UIView+TestHelpers.swift
@@ -1,0 +1,15 @@
+//
+//  UIView+TestHelpers.swift
+//  EssentialAppTests
+//
+//  Created by Andrey on 9/26/22.
+//
+
+import UIKit
+
+extension UIView {
+    func enforceLayoutCycle() {
+        layoutIfNeeded()
+        RunLoop.current.run(until: Date())
+    }
+}

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedViewController.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedViewController.swift
@@ -17,6 +17,7 @@ final public class FeedViewController: UITableViewController, UITableViewDataSou
     private var tableModel = [FeedImageCellController]() {
         didSet { tableView.reloadData() }
     }
+    private var loadingControllers = [IndexPath: FeedImageCellController]()
     
     @IBOutlet private(set) public var errorView: ErrorView?
     
@@ -37,6 +38,7 @@ final public class FeedViewController: UITableViewController, UITableViewDataSou
     }
     
     public func display(_ cellControllers: [FeedImageCellController]) {
+        loadingControllers = [:]
         tableModel = cellControllers
     }
     
@@ -61,7 +63,9 @@ final public class FeedViewController: UITableViewController, UITableViewDataSou
     }
     
     private func cellController(forRowAt indexPath: IndexPath) -> FeedImageCellController {
-        return tableModel[indexPath.row]
+        let controller = tableModel[indexPath.row]
+        loadingControllers[indexPath] = controller
+        return controller
     }
     
     public func tableView(_ tableView: UITableView, cancelPrefetchingForRowsAt indexPaths: [IndexPath]) {
@@ -73,7 +77,8 @@ final public class FeedViewController: UITableViewController, UITableViewDataSou
     }
     
     private func cancelLoadInCellController(for indexPath: IndexPath) {
-        cellController(forRowAt: indexPath).cancelLoad()
+        loadingControllers[indexPath]?.cancelLoad()
+        loadingControllers[indexPath] = nil
     }
 }
 


### PR DESCRIPTION
When updating the table model and reloading table view, UIKit calls `didEndDisplayingCell` for each removed cell. Since we are cancelling image data load request in this method, we could be sending messages to wrong controllers or potentially crashing app if new model has fewer elements than old.

This is not a big problem currently, since items can't be removed from the feed. However we cannot assume the backend will keep this behavior going further. 